### PR TITLE
Update transformer_flux.py. Change float64 to float32

### DIFF
--- a/src/diffusers/models/transformers/transformer_flux.py
+++ b/src/diffusers/models/transformers/transformer_flux.py
@@ -38,7 +38,7 @@ logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 def rope(pos: torch.Tensor, dim: int, theta: int) -> torch.Tensor:
     assert dim % 2 == 0, "The dimension must be even."
 
-    scale = torch.arange(0, dim, 2, dtype=torch.float64, device=pos.device) / dim
+    scale = torch.arange(0, dim, 2, dtype=torch.float32, device=pos.device) / dim
     omega = 1.0 / (theta**scale)
 
     batch_size, seq_length = pos.shape


### PR DESCRIPTION
dtype=torch.float64 is overkill, and float64 is not defined for certain devices such as Apple Silicon mps.

# What does this PR do?

Enables the flux transformer to be used on devices such as Apple Silicon mps by redefining float64 as float32, which does not negatively effect the output of the pipeline.
